### PR TITLE
Add constant to set musigen size, changing it to medium to be compatible with the projection

### DIFF
--- a/train.py
+++ b/train.py
@@ -12,6 +12,9 @@ from pathlib import Path
 import torch.nn as nn
 from transformers import get_scheduler
 from tqdm import tqdm
+
+MUSICGEN_MODEL = "facebook/musicgen-medium"
+
 criterion = nn.CrossEntropyLoss()
 grad_acc = 8
 
@@ -76,13 +79,13 @@ class DistributedMusicGenTrainer:
     def train_process(self, rank: int, world_size: int):
         self.setup_process(rank, world_size)
         
-        base_model = MusicGen.get_pretrained('facebook/musicgen-small')
+        base_model = MusicGen.get_pretrained(MUSICGEN_MODEL)
         lm_dict = base_model.lm.state_dict()
 
-        lm = load_lm_model(lm_dict, "facebook/musicgen-small", device="cuda")
-        
-        compression_model = load_compression_model("facebook/musicgen-small", device="cuda")
-        model = VideoMusicGen('small',
+        lm = load_lm_model(lm_dict, MUSICGEN_MODEL, device="cuda")
+
+        compression_model = load_compression_model(MUSICGEN_MODEL, device="cuda")
+        model = VideoMusicGen(MUSICGEN_MODEL.strip('-')[-1],
                            compression_model=compression_model,
                            lm=lm,
                            max_duration=30)


### PR DESCRIPTION
So, you are using musicgen-small
https://github.com/havenpersona/ossl-v1/blob/23428c63410a5909f952f06976f77d49452b9115/train.py#L79

But projecting to musicgen-medium dim
https://github.com/havenpersona/ossl-v1/blob/23428c63410a5909f952f06976f77d49452b9115/audiocraft/modules/adapted_transformer.py#L912

Just made a hotfix, but it would be great to have an easy way to set both the model and projection sizes all at once.
For those not familiar with musicgen, small uses 1024, medium 1536, and large 2048 in their projections.